### PR TITLE
update: プロフィールを日本語版と英語版に分割

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-Akihiro Tamari (玉利 彰浩)
+Akihiro Tamari
 ====================
 
 Hi there :wave:, I'm freelance web engineer in Japan.
@@ -55,8 +55,8 @@ About me
     <tbody>
         <tr>
             <td>
-                Oct.2023 - Jul.2024<br>
-                (7 months)
+                Nov.2023 - Jul.2024<br>
+                (9 months)
             </td>
             <td>病院向けHRシステム開発</td>
             <td align="center">4</td>
@@ -79,7 +79,7 @@ About me
         <tr>
             <td>
                 Oct.2023 - Jun.2024<br>
-                (6 months)
+                (9 months)
             </td>
             <td>暗号資産ウォレット管理システム開発</td>
             <td align="center">10+</td>
@@ -479,7 +479,7 @@ About me
         <tr>
             <td>
                 Jan.2010 - Feb.2010<br>
-                (1 months)
+                (2 months)
             </td>
             <td>ソフトバンク・DoCoMo フィーチャーフォン用単語帳アプリ開発</td>
             <td align="center">1</td>
@@ -527,7 +527,7 @@ About me
             <td align="center">20+</td>
             <td>
                 <ul>
-                    <li>Software Development</li>
+                    <li>Backend Development</li>
                     <li>Writing Documentation</li>
                 </ul>
             </td>
@@ -544,8 +544,8 @@ About me
 Profiles
 --------------------
 
-- 日本語
-- [English](README.en.md)
+- [日本語](README.md)
+- English
 
 --------------------
 

--- a/README.en.md
+++ b/README.en.md
@@ -29,6 +29,7 @@ About me
 ![MySQL](https://img.shields.io/badge/MySQL-4479A1?logo=mysql&logoColor=FFF)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=FFF)
 ![Redis](https://img.shields.io/badge/Redis-DC382D?logo=redis&logoColor=FFF)
+![Spanner](https://img.shields.io/badge/Spanner-EEEEEE?logo=googlecloudspanner)
 
 ![Apache](https://img.shields.io/badge/Apache-D22128?logo=apache)
 ![NGINX](https://img.shields.io/badge/NGINX-009639?logo=nginx)

--- a/README.en.md
+++ b/README.en.md
@@ -163,6 +163,7 @@ About me
                 <ul>
                     <li>Ruby</li>
                     <li>Ruby on Rails</li>
+                    <li>Vue.js</li>
                     <li>NGINX</li>
                     <li>PostgreSQL</li>
                     <li>Redis</li>

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ About me
                 <ul>
                     <li>Ruby</li>
                     <li>Ruby on Rails</li>
+                    <li>Vue.js</li>
                     <li>NGINX</li>
                     <li>PostgreSQL</li>
                     <li>Redis</li>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-Akihiro Tamari (玉利 彰浩)
+玉利 彰浩
 ====================
 
-Hi there :wave:, I'm freelance web engineer in Japan.
+はじめまして :wave:<br>
+私は日本でフリーランスのWebエンジニアをしています。
 
 About me
 --------------------
 
-10+ years of experience in developing.
+私は実務での開発経験が10年以上あります。
 
 ### Skills
 
@@ -40,30 +41,30 @@ About me
 
 ### Works
 
-#### Professional Experience
+#### 職務経歴
 
 <table>
     <thead>
         <tr>
-            <th>Term</th>
-            <th>Project</th>
-            <th>Team Size</th>
-            <th>Responsibilities</th>
-            <th>Technologies Employed</th>
+            <th>期間</th>
+            <th>プロジェクト</th>
+            <th>メンバー数</th>
+            <th>職務内容</th>
+            <th>採用技術</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td>
-                Oct.2023 - Jul.2024<br>
-                (7 months)
+                2023年11月 - 2024年7月<br>
+                (9ヶ月)
             </td>
             <td>病院向けHRシステム開発</td>
-            <td align="center">4</td>
+            <td align="center">4名</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
-                    <li>Frontend Development</li>
+                    <li>バックエンド開発</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -78,14 +79,14 @@ About me
         </tr>
         <tr>
             <td>
-                Oct.2023 - Jun.2024<br>
-                (6 months)
+                2023年10月 - 2024年6月<br>
+                (9ヶ月)
             </td>
             <td>暗号資産ウォレット管理システム開発</td>
-            <td align="center">10+</td>
+            <td align="center">10名以上</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
+                    <li>バックエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -98,17 +99,17 @@ About me
         </tr>
         <tr>
             <td>
-                Dec.2020 - Sep.2023<br>
-                (2 years 10 months)
+                2020年12月 - 2023年9月<br>
+                (2年 10ヶ月)
             </td>
             <td>
                 スマートフォン向けゲームアプリのバックエンド開発<br>
                 (ネイティブアプリ)
             </td>
-            <td align="center">40+</td>
+            <td align="center">40名以上</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
+                    <li>バックエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -125,15 +126,15 @@ About me
         </tr>
         <tr>
             <td>
-                May.2020 - Jan.2022<br>
-                (1 years 9 months)
+                2020年5月 - 2022年1月<br>
+                (1年 9ヶ月)
             </td>
             <td>ブランド品のECサイト運用開発</td>
-            <td align="center">2</td>
+            <td align="center">2名</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
-                    <li>Frontend Development</li>
+                    <li>バックエンド開発</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -148,15 +149,15 @@ About me
         </tr>
         <tr>
             <td>
-                Jun.2019 - Jul.2020<br>
-                (1 years 2 months)
+                2019年6月 - 2020年7月<br>
+                (1年 2ヶ月)
             </td>
             <td>訪問診療サービス業務支援システム開発</td>
-            <td align="center">5</td>
+            <td align="center">5名</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
-                    <li>Frontend Development</li>
+                    <li>バックエンド開発</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -173,14 +174,14 @@ About me
         </tr>
         <tr>
             <td>
-                Nov.2018 - Mar.2020<br>
-                (1 years 5 months)
+                2018年11月 - 2020年3月<br>
+                (1年 5ヶ月)
             </td>
             <td>IaaSサービス開発</td>
-            <td align="center">10+</td>
+            <td align="center">10名以上</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
+                    <li>バックエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -194,14 +195,14 @@ About me
         </tr>
         <tr>
             <td>
-                Jun.2018 - Oct.2018<br>
-                (5 months)
+                2018年6月 - 2018年10月<br>
+                (5ヶ月)
             </td>
             <td>子供向けプログラミング教育サービス開発</td>
-            <td align="center">10+</td>
+            <td align="center">10名以上</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
+                    <li>バックエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -216,17 +217,17 @@ About me
         </tr>
         <tr>
             <td>
-                May.2014 - May.2018<br>
-                (4 years 1 months)
+                2014年5月 - 2018年5月<br>
+                (4年 1ヶ月)
             </td>
             <td>
                 スマートフォン向けソーシャルゲームのバックエンド開発<br>
                 (ネイティブアプリ)
             </td>
-            <td align="center">30+</td>
+            <td align="center">30名以上</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
+                    <li>バックエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -249,17 +250,17 @@ About me
         </tr>
         <tr>
             <td>
-                Nov.2013 - Apr.2014<br>
-                (6 months)
+                2013年11月 - 2014年4月<br>
+                (6ヶ月)
             </td>
             <td>
                 スマートフォン向けソーシャルゲームの開発<br>
                 (ブラウザアプリ)
             </td>
-            <td align="center">20+</td>
+            <td align="center">20名以上</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
+                    <li>バックエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -276,15 +277,15 @@ About me
         </tr>
         <tr>
             <td>
-                Oct.2012 - Sep.2013<br>
-                (1 years)
+                2012年10月 - 2013年9月<br>
+                (1年)
             </td>
             <td>Facebookページ効果測定ツール開発</td>
-            <td align="center">10+</td>
+            <td align="center">10名以上</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
-                    <li>Frontend Development</li>
+                    <li>バックエンド開発</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -306,18 +307,18 @@ About me
         </tr>
         <tr>
             <td>
-                Aug.2011 - Aug.2012<br>
-                (1 years 1 months)
+                2011年8月 - 2012年8月<br>
+                (1年 1ヶ月)
             </td>
             <td>
                 フィーチャーフォン、スマートフォン向けソーシャルゲームの開発<br>
                 (ブラウザアプリ)
             </td>
-            <td align="center">20+</td>
+            <td align="center">20名以上</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
-                    <li>Frontend Development</li>
+                    <li>バックエンド開発</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -338,14 +339,14 @@ About me
         </tr>
         <tr>
             <td>
-                Nov.2010 - Jul.2011<br>
-                (9 months)
+                2010年11月 - 2011年7月<br>
+                (9ヶ月)
             </td>
             <td>iPhoneアプリクチコミサイト構築</td>
-            <td align="center">3</td>
+            <td align="center">3名</td>
             <td>
                 <ul>
-                    <li>Full Stack Development</li>
+                    <li>開発全般</li>
                 </ul>
             </td>
             <td>
@@ -363,15 +364,15 @@ About me
         </tr>
         <tr>
             <td>
-                Sep.2010 - Oct.2010<br>
-                (2 months)
+                2010年9月 - 2010年10月<br>
+                (2ヶ月)
             </td>
             <td>ネイルサロンポータルサイト改修</td>
-            <td align="center">1</td>
+            <td align="center">1名</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
-                    <li>Frontend Development</li>
+                    <li>バックエンド開発</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -387,15 +388,15 @@ About me
         </tr>
         <tr>
             <td>
-                Aug.2010 - Oct.2010<br>
-                (3 months)
+                2010年8月 - 2010年10月<br>
+                (3ヶ月)
             </td>
             <td>不動産会社 情報管理システム開発</td>
-            <td align="center">3</td>
+            <td align="center">3名</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
-                    <li>Frontend Development</li>
+                    <li>バックエンド開発</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -411,14 +412,14 @@ About me
         </tr>
         <tr>
             <td>
-                May.2010 - May.2010<br>
-                (1 months)
+                2010年5月 - 2010年5月<br>
+                (1ヶ月)
             </td>
             <td>ブログデザインのコーディング</td>
-            <td align="center">2</td>
+            <td align="center">2名</td>
             <td>
                 <ul>
-                    <li>Frontend Development</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -432,14 +433,14 @@ About me
         </tr>
         <tr>
             <td>
-                Apr.2010 - Jul.2010<br>
-                (4 months)
+                2010年4月 - 2010年7月<br>
+                (4ヶ月)
             </td>
             <td>自社PHPフレームワークバージョンアップ</td>
-            <td align="center">2</td>
+            <td align="center">2名</td>
             <td>
                 <ul>
-                    <li>Software Development</li>
+                    <li>ソフトウェア開発</li>
                 </ul>
             </td>
             <td>
@@ -454,15 +455,15 @@ About me
         </tr>
         <tr>
             <td>
-                Feb.2010 - Mar.2010<br>
-                (2 months)
+                2010年2月 - 2010年3月<br>
+                (2ヶ月)
             </td>
             <td>病院 問診票システム開発</td>
-            <td align="center">3</td>
+            <td align="center">3名</td>
             <td>
                 <ul>
-                    <li>Backend Development</li>
-                    <li>Frontend Development</li>
+                    <li>バックエンド開発</li>
+                    <li>フロントエンド開発</li>
                 </ul>
             </td>
             <td>
@@ -478,14 +479,14 @@ About me
         </tr>
         <tr>
             <td>
-                Jan.2010 - Feb.2010<br>
-                (1 months)
+                2010年1月 - 2010年2月<br>
+                (2ヶ月)
             </td>
             <td>ソフトバンク・DoCoMo フィーチャーフォン用単語帳アプリ開発</td>
-            <td align="center">1</td>
+            <td align="center">1名</td>
             <td>
                 <ul>
-                    <li>Software Development</li>
+                    <li>ソフトウェア開発</li>
                 </ul>
             </td>
             <td>
@@ -498,14 +499,14 @@ About me
         </tr>
         <tr>
             <td>
-                Oct.2009 - Jan.2010<br>
-                (3 months)
+                2009年10月 - 2010年1月<br>
+                (3ヶ月)
             </td>
             <td>自社PHPフレームワーク開発</td>
-            <td align="center">2</td>
+            <td align="center">2名</td>
             <td>
                 <ul>
-                    <li>Software Development</li>
+                    <li>ソフトウェア開発</li>
                 </ul>
             </td>
             <td>
@@ -520,15 +521,15 @@ About me
         </tr>
         <tr>
             <td>
-                Jul.2008 - Jun.2009<br>
-                (1 years)
+                2008年7月 - 2009年6月<br>
+                (1年)
             </td>
             <td>大手インターネットサービスプロバイダの社内業務用システム開発</td>
-            <td align="center">20+</td>
+            <td align="center">20名以上</td>
             <td>
                 <ul>
-                    <li>Software Development</li>
-                    <li>Writing Documentation</li>
+                    <li>バックエンド開発</li>
+                    <li>ドキュメント作成</li>
                 </ul>
             </td>
             <td>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ About me
 ![MySQL](https://img.shields.io/badge/MySQL-4479A1?logo=mysql&logoColor=FFF)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=FFF)
 ![Redis](https://img.shields.io/badge/Redis-DC382D?logo=redis&logoColor=FFF)
+![Spanner](https://img.shields.io/badge/Spanner-EEEEEE?logo=googlecloudspanner)
 
 ![Apache](https://img.shields.io/badge/Apache-D22128?logo=apache)
 ![NGINX](https://img.shields.io/badge/NGINX-009639?logo=nginx)


### PR DESCRIPTION
# 概要
- プロフィールの日本語と英語を分割
- スキルにSpannerを追加
- 既存の職務経歴の修正
  - 採用技術の記載漏れを修正